### PR TITLE
fix: changing eslint.config to fix identation problem

### DIFF
--- a/front-end/eslint.config.js
+++ b/front-end/eslint.config.js
@@ -33,7 +33,7 @@ export default tseslint.config(
         "warn",
         {
           tabWidth: 2,
-          useTabs: false,
+          useTabs: true,
         },
       ],
       "comma-dangle": ["error", "always-multiline"],


### PR DESCRIPTION
**The issue:**

When we open a pull request, and go to the Files changed tab, we can see that the code it's being displayed with a weird identation:

![Screenshot from 2025-03-28 15-32-53](https://github.com/user-attachments/assets/8da16ac8-fbbf-4a4f-995b-c03bcc8b2ea7)

Even though this is not the way that was made on the IDE:

![Screenshot from 2025-03-28 15-33-14](https://github.com/user-attachments/assets/b4b0825c-ae2e-4be1-a7ba-cfb6db5f9fd2)

**The cause:**

This issue is happening because of a wrong config on prettier and eslint, where both were not following the same config to set the property `useTabs` as true. Making them use the same value seems to solve this issue.